### PR TITLE
use chroma red and green for color-green and color-red

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -29,8 +29,8 @@
     --blockquote-bg: #fff;
     --hover: #d73a49;
     --grey: #ccc;
-    --success: #50fa7b;
-    --error: #ff5555;
+    --success: #388038;
+    --error: #c02828;
   }
 }
 
@@ -48,8 +48,8 @@
     --blockquote-bg: #414558;
     --hover: #ff80bf;
     --grey: #414558;
-    --success: #50fa7b;
-    --error: #ff5555;
+    --success: #388038;
+    --error: #c02828;
   }
 }
 


### PR DESCRIPTION
This PR updates the green and red colors to match the green and red provided by chroma. I thought the brighter green was a little hard to read and thought using the existing green on the page would improve the readability. 

I also checked that the `--success` and `--error` variables were not being used elsewhere:

```
$ git grep -n -e '--error' -e '--success'
static/main.css:32:    --success: #50fa7b;
static/main.css:33:    --error: #ff5555;
static/main.css:51:    --success: #50fa7b;
static/main.css:52:    --error: #ff5555;
static/main.css:254:  color: var(--success);
static/main.css:258:  color: var(--error);
```

## Before

<img width="938" alt="Screenshot 2024-01-03 at 19 45 14" src="https://github.com/picosh/pgit/assets/3824954/4afccfb2-71f0-411b-9573-64ae481062fa">

## After

<img width="971" alt="Screenshot 2024-01-03 at 19 42 44" src="https://github.com/picosh/pgit/assets/3824954/ddcdf0b2-b56e-4abf-931a-06bb9ba68246">
