### PR TITLE
Fix issue #7.

### DIFF
--- a/static/smol.css
+++ b/static/smol.css
@@ -92,7 +92,7 @@ pre {
   border-radius: 1px;
   padding: var(--line-height);
   overflow-x: auto;
-  background-color: var(--pre) !important;
+  background-color: var(--pre);
 }
 
 small {


### PR DESCRIPTION
Remove !important to ensure background color of pre blocks is not inadvertently overwritten.